### PR TITLE
Idea: use Data Container as declarative DataManager

### DIFF
--- a/alabastia-petclinic/modules/web/src/com/alabastia/petclinic/web/screens/visit/AlabastiaVisitEdit.java
+++ b/alabastia-petclinic/modules/web/src/com/alabastia/petclinic/web/screens/visit/AlabastiaVisitEdit.java
@@ -1,44 +1,81 @@
 package com.alabastia.petclinic.web.screens.visit;
 
-import com.haulmont.cuba.core.global.DataManager;
+import com.alabastia.petclinic.entity.AlabastiaVisit;
+import com.alabastia.petclinic.entity.DefaultTreatmentRoom;
+import com.alabastia.petclinic.entity.TreatmentRoom;
+import com.haulmont.cuba.core.global.EntityAccessException;
 import com.haulmont.cuba.core.global.EntityStates;
-import com.haulmont.cuba.core.global.View;
+import com.haulmont.cuba.gui.Notifications;
+import com.haulmont.cuba.gui.Notifications.NotificationType;
+import com.haulmont.cuba.gui.Route;
+import com.haulmont.cuba.gui.model.CollectionLoader;
+import com.haulmont.cuba.gui.model.InstanceContainer;
+import com.haulmont.cuba.gui.model.InstanceLoader;
+import com.haulmont.cuba.gui.screen.EditedEntityContainer;
+import com.haulmont.cuba.gui.screen.LoadDataBeforeShow;
+import com.haulmont.cuba.gui.screen.StandardEditor;
 import com.haulmont.cuba.gui.screen.Subscribe;
 import com.haulmont.cuba.gui.screen.UiController;
 import com.haulmont.cuba.gui.screen.UiDescriptor;
 import com.haulmont.cuba.security.entity.User;
 import com.haulmont.cuba.security.global.UserSession;
+import com.haulmont.sample.petclinic.entity.visit.Visit;
 import com.haulmont.sample.petclinic.web.screens.visit.VisitEdit;
-import com.alabastia.petclinic.entity.DefaultTreatmentRoom;
-import com.alabastia.petclinic.entity.AlabastiaVisit;
-import com.alabastia.petclinic.entity.TreatmentRoom;
-import java.util.Optional;
 import javax.inject.Inject;
 
 @UiController("petclinic_Visit.edit")
 @UiDescriptor("alabastia-visit-edit.xml")
-public class AlabastiaVisitEdit extends VisitEdit {
+@EditedEntityContainer("visitDc")
+@Route(value = "visits/edit", parentPrefix = "visits")
+public class AlabastiaVisitEdit extends StandardEditor<AlabastiaVisit> {
 
-    @Inject
-    protected DataManager dataManager;
     @Inject
     protected UserSession userSession;
     @Inject
     protected EntityStates entityStates;
+    @Inject
+    protected InstanceContainer<DefaultTreatmentRoom> defaultTreatmentRoomDc;
+    @Inject
+    protected InstanceLoader<DefaultTreatmentRoom> defaultTreatmentRoomLc;
+    @Inject
+    protected CollectionLoader<TreatmentRoom> treatmentRoomsDl;
+    @Inject
+    protected Notifications notifications;
+
+    @Subscribe
+    protected void onInit(InitEvent event) {
+        // provide the declarative dataContainer with required parameter
+        defaultTreatmentRoomLc.setParameter("currentUser", currentUser());
+    }
+
+    @Subscribe
+    protected void onBeforeShow(BeforeShowEvent event) {
+        treatmentRoomsDl.load();
+    }
+
 
     @Subscribe
     protected void onAfterShow(AfterShowEvent event) {
 
         if (entityStates.isNew(getEditedEntity())) {
+
             getEditedEntity().setAssignedNurse(
                 currentUser()
             );
+            try {
+                defaultTreatmentRoomLc.load();
 
-            defaultTreatmentRoomFor(
-                currentUser()
-            ).ifPresent(defaultTreatmentRoom ->
-                initTreatmentRoom(defaultTreatmentRoom.getTreatmentRoom())
-            );
+                // retrieve a possible configured default treatment room through declarative dataContainer
+                final TreatmentRoom defaultTreatmentRoom =
+                    defaultTreatmentRoomDc.getItem().getTreatmentRoom();
+
+                initTreatmentRoom(defaultTreatmentRoom);
+            }
+            catch (EntityAccessException e) {
+                notifications.create(NotificationType.TRAY)
+                    .withCaption("Default Treatment Room not configured...")
+                    .show();
+            }
         }
     }
 
@@ -50,16 +87,5 @@ public class AlabastiaVisitEdit extends VisitEdit {
     private User currentUser() {
         return userSession.getCurrentOrSubstitutedUser();
     }
-
-    private Optional<DefaultTreatmentRoom> defaultTreatmentRoomFor(User user) {
-        return dataManager
-            .load(DefaultTreatmentRoom.class)
-            .query("e.user = ?1", user)
-            .view(viewBuilder ->
-                viewBuilder.add("treatmentRoom", View.MINIMAL)
-            )
-            .optional();
-    }
-
 
 }

--- a/alabastia-petclinic/modules/web/src/com/alabastia/petclinic/web/screens/visit/alabastia-visit-edit.xml
+++ b/alabastia-petclinic/modules/web/src/com/alabastia/petclinic/web/screens/visit/alabastia-visit-edit.xml
@@ -4,9 +4,20 @@
   xmlns:ext="http://schemas.haulmont.com/cuba/window-ext.xsd"
   extends="com/haulmont/sample/petclinic/web/screens/visit/visit-edit.xml">
   <data>
+    <instance id="defaultTreatmentRoomDc"
+      class="com.alabastia.petclinic.entity.DefaultTreatmentRoom">
+      <view extends="_local">
+        <property name="treatmentRoom" view="_minimal" />
+      </view>
+      <loader id="defaultTreatmentRoomLc">
+        <query>
+          <![CDATA[select e from alabastiapetclinic_DefaultTreatmentRoom e where e.user = :currentUser]]>
+        </query>
+      </loader>
+    </instance>
     <collection id="treatmentRoomsDc" class="com.alabastia.petclinic.entity.TreatmentRoom"
       view="_minimal">
-      <loader>
+      <loader id="treatmentRoomsDl">
         <query>
           <![CDATA[select e from alabastiapetclinic_TreatmentRoom e]]>
         </query>


### PR DESCRIPTION

#### Idea: Declarative DataManager Loading

In this branch the default treatment room in the UI is not loaded via `dataManager.load(DefaultTreatmentRoom.class).query("...").optional()`.

Instead, the `dataCotainer` concept is utilized to define the loading of the optional instance
of the `DefaultTreatmentRoom` in a declarative XML based manner. This way, the java code is simplified in the controller. It only requires to define the parameter as well as pick up the value via `defaultTreatmentRoomDc.getItem()`.

#### The Reason: higher level abstraction

The reason behind it is the same which led to the introduction of the various screen facets like the `MessageDialogFacet`. It pushes the complexity of "how to load a particular entity" into the declarative XML part. The Java code then can just rely on the `defaultTreatmentRoomDc` to correctly fetched the data. This simplifies the java code and provides a higher level abstraction in the UI controller to work with.


#### Example: Default Treatment Room Lookup

The declarative definition of the instance container looks like this:


```xml
<instance id="defaultTreatmentRoomDc"
      class="com.alabastia.petclinic.entity.DefaultTreatmentRoom">
  <view extends="_local">
    <property name="treatmentRoom" view="_minimal" />
  </view>
  <loader id="defaultTreatmentRoomLc">
    <query>
      <![CDATA[select e from alabastiapetclinic_DefaultTreatmentRoom e where e.user = :currentUser]]>
    </query>
  </loader>
</instance>
```


The controller code is simplified as described above:

```java
public class AlabastiaVisitEdit extends VisitEdit {
    @Inject
    protected InstanceContainer<DefaultTreatmentRoom> defaultTreatmentRoomDc;
    @Inject
    protected InstanceLoader<DefaultTreatmentRoom> defaultTreatmentRoomLc;

    @Subscribe
    protected void onInit(InitEvent event) {
        // provide the declarative dataContainer with required parameter
        defaultTreatmentRoomLc.setParameter("currentUser", currentUser());
    }
    
    @Subscribe
    protected void onAfterShow(AfterShowEvent event) {

        if (entityStates.isNew(getEditedEntity())) {

            getEditedEntity().setAssignedNurse(
                currentUser()
            );

            // retrieve a possible configured default treatment room through declarative dataContainer
            final TreatmentRoom defaultTreatmentRoom =
                defaultTreatmentRoomDc.getItem().getTreatmentRoom();

            initTreatmentRoom(defaultTreatmentRoom);
        }
    }
}
```



### Current Problems with the declarative approach

Currently it works well for the happy path: the `instanceContainer` actually returns a value. The problem occurs when there is no result. For a regular `instanceContainer` this is not very often the case, because
normally an instance container is not used together with an associated data loader and a query.

But in this situation, the instance not being present by the query might be a valid business situation.

Currently, the `InstanceLoaderImpl` throws an exception in case the entity is not found:

```java
entity = getDataManager().load(loadContext);

if (entity == null) {
    throw new EntityAccessException(container.getEntityMetaClass(), entityId);
}
```


Therefore, it requires in the controller to catch this exception as well as explicitly trigger the dataLoader.load() in order to programmatically catch the exception.


### Proposed Solution

In order to make the usage of `dataContainer` as a declarative way of using the `dataManager` for this scenario work, it should be possible to mark an instance container as optional. This way when the `instanceContainer` is loaded and no result is found `getItem()` would either return null or alternatively an instance of `Optional<DefaultTreatmentRoom>`.

The resulting XML:



```xml
<instance id="defaultTreatmentRoomDc"
      optional="true"
      class="com.alabastia.petclinic.entity.DefaultTreatmentRoom">
  <view extends="_local">
    <property name="treatmentRoom" view="_minimal" />
  </view>
      <loader id="defaultTreatmentRoomLc">
        <query>
          <![CDATA[select e from alabastiapetclinic_DefaultTreatmentRoom e where e.user = :currentUser]]>
        </query>
      </loader>
</instance>
```
 
The corresponding controller code:

```java
public class AlabastiaVisitEdit extends VisitEdit {
    @Inject
    protected InstanceContainer<DefaultTreatmentRoom> defaultTreatmentRoomDc;
    @Inject
    protected InstanceLoader<DefaultTreatmentRoom> defaultTreatmentRoomLc;

    @Subscribe
    protected void onInit(InitEvent event) {
        // provide the declarative dataContainer with required parameter
        defaultTreatmentRoomLc.setParameter("currentUser", currentUser());
    }
    
    @Subscribe
    protected void onAfterShow(AfterShowEvent event) {

        if (entityStates.isNew(getEditedEntity())) {

            getEditedEntity().setAssignedNurse(
                currentUser()
            );

            // retrieve a possible configured default treatment room through declarative dataContainer
            if (defaultTreatmentRoomDc.getItem() != null) {
               final TreatmentRoom defaultTreatmentRoom =
                               defaultTreatmentRoomDc.getItem().getTreatmentRoom();
               
               initTreatmentRoom(defaultTreatmentRoom); 
            }
        }
    }
}
```

With this non-exception-when-null behavior it would also not require to explicitly trigger the dataLoader load anymore and the `@LoadDataBeforeShow`